### PR TITLE
Refactor reporters

### DIFF
--- a/src/helpers/collectReports.ts
+++ b/src/helpers/collectReports.ts
@@ -1,38 +1,26 @@
 import { flatten } from 'lodash';
-import { Reporter, Report } from '../typings/reporter';
+import { PageReporter, Report, GenericReporter } from '../typings/reporter';
 import bluebird from 'bluebird';
-import { GlobalConfig } from '../config';
 
 type CollectReportsOptions = {
-  url: string;
-  config: GlobalConfig;
-  reporters: Array<
-    new (
-      url: string,
-      config?: Pick<GlobalConfig, keyof GlobalConfig>,
-    ) => Reporter
-  >;
+  reporters: Array<{ name: string; instance: PageReporter | GenericReporter }>;
   concurrency?: number;
 };
 
 export const collectReports = async ({
-  url,
   reporters,
-  config,
   concurrency = 3,
 }: CollectReportsOptions) => {
   return flatten(
     await bluebird.map(
       reporters,
-      async (ReporterClass): Promise<Report[]> => {
+      async ({ name, instance }): Promise<Report[]> => {
         try {
-          const r = new ReporterClass(url, config);
-
-          return r.getReports();
+          return instance.getReports();
         } catch (error) {
           return [
             {
-              name: ReporterClass.name,
+              name,
               error,
             },
           ];

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -23,10 +23,10 @@ export const formatBytesAsKibibytes = flow(
 
 export const formatHasPassed = (hasPassed?: boolean) =>
   hasPassed === true
-    ? 'Passed :heavy_check_mark:'
-    : hasPassed === false ? 'Failed ❌' : defaultFormat(undefined);
+    ? ':heavy_check_mark: Passed'
+    : hasPassed === false ? '❌ Failed' : defaultFormat(undefined);
 
 export const formatYesOrNo = (result?: boolean | null) =>
   result === true
-    ? 'Yes :heavy_check_mark:'
-    : result === false ? 'No ❌' : defaultFormat(undefined);
+    ? ':heavy_check_mark: Yes'
+    : result === false ? '❌ No' : defaultFormat(undefined);

--- a/src/helpers/renderReport.ts
+++ b/src/helpers/renderReport.ts
@@ -1,36 +1,20 @@
-import { source, stripIndents } from 'common-tags';
+import { source } from 'common-tags';
 import { Report } from '../typings/reporter';
 
-type GeneratedAggregatedReportOptions = {
-  reports: Report[];
+export const renderReport = (report: Report, { headingLevel = 2 }) => {
+  if ('error' in report) {
+    return `Failed to run this reporter: ${report.error.message}`;
+  } else {
+    const title = report.url ? `[${report.name}](${report.url})` : report.name;
+
+    return source`
+      ${'#'.repeat(headingLevel)} ${title}
+
+      ${report.testName || 'Test'} | ${report.scoreNames.join(' | ')}
+      -----${'|---'.repeat(report.scoreNames.length)}
+      ${report.records.map(({ name, scores, formatScore }) => {
+        return `${name} | ${scores.map(formatScore).join(' | ')}`;
+      })}
+    `;
+  }
 };
-
-export const renderReport = ({
-  reports,
-}: GeneratedAggregatedReportOptions) => stripIndents`
-  ${source`
-    ${reports.map(report => {
-      let body: string;
-
-      if ('error' in report) {
-        body = `Failed to run this reporter: ${report.error.message}`;
-      } else {
-        body = source`
-          ${report.testName || 'Test'} | ${report.scoreNames.join(' | ')}
-          -----| ${Array(report.scoreNames.length)
-            .fill('-------------')
-            .join('|')}
-          ${report.records.map(({ name, scores, formatScore }) => {
-            return `${name} | ${scores.map(formatScore).join(' | ')}`;
-          })}
-      `;
-      }
-
-      return `\n${source`
-        ### ${report.url ? `[${report.name}](${report.url})` : report.name}
-
-        ${body}
-      `}`;
-    })}
-  `}
-`;

--- a/src/reporters/AwsHealthReporter.ts
+++ b/src/reporters/AwsHealthReporter.ts
@@ -1,4 +1,4 @@
-import { Reporter, Report } from '../typings/reporter';
+import { GenericReporter, Report } from '../typings/reporter';
 import awsSdk from 'aws-sdk';
 
 const formatAwsHealth = (color: 'Green' | 'Red' | 'Yellow' | 'Grey') => {
@@ -14,10 +14,10 @@ const formatAwsHealth = (color: 'Green' | 'Red' | 'Yellow' | 'Grey') => {
   }
 };
 
-export class AwsHealthReporter implements Reporter {
+export class AwsHealthReporter implements GenericReporter {
   private eb: AWS.ElasticBeanstalk;
 
-  constructor(_url: string) {
+  constructor() {
     this.eb = new awsSdk.ElasticBeanstalk({
       apiVersion: '2010-12-01',
     });

--- a/src/reporters/MobileFriendlinessReporter.ts
+++ b/src/reporters/MobileFriendlinessReporter.ts
@@ -1,5 +1,5 @@
 import got from 'got';
-import { Reporter, Report } from '../typings/reporter';
+import { PageReporter, Report } from '../typings/reporter';
 import { formatHasPassed, formatYesOrNo } from '../helpers/format';
 import { find } from 'lodash';
 import { GlobalConfig } from '../config';
@@ -56,7 +56,7 @@ type GoogleMobileFriendlinessTestResponse = {
   };
 };
 
-export class MobileFriendlinessReporter implements Reporter {
+export class MobileFriendlinessReporter implements PageReporter {
   private url: string;
   private key: string;
 

--- a/src/reporters/SecurityHeadersReporter.ts
+++ b/src/reporters/SecurityHeadersReporter.ts
@@ -1,8 +1,8 @@
 import got from 'got';
-import { Reporter, Report } from '../typings/reporter';
+import { PageReporter, Report } from '../typings/reporter';
 import { defaultFormat } from '../helpers/format';
 
-export class SecurityHeadersReporter implements Reporter {
+export class SecurityHeadersReporter implements PageReporter {
   private url: string;
 
   constructor(url: string) {

--- a/src/reporters/WebPageTestReporter.ts
+++ b/src/reporters/WebPageTestReporter.ts
@@ -1,4 +1,4 @@
-import { Reporter, Report, TestRecord } from '../typings/reporter';
+import { PageReporter, Report, TestRecord } from '../typings/reporter';
 
 import WebPageTest, { TestResults, RunTestResponse } from 'webpagetest';
 import bluebird from 'bluebird';
@@ -21,7 +21,7 @@ import {
 } from '../helpers/format';
 import { GlobalConfig } from '../config';
 
-export class WebPageTestReporter implements Reporter {
+export class WebPageTestReporter implements PageReporter {
   // tslint:disable-next-line:no-multiline-string
   static customUserAgent = oneLine`
     Mozilla/5.0 (Linux;

--- a/src/typings/reporter.ts
+++ b/src/typings/reporter.ts
@@ -24,7 +24,21 @@ export type Report = {
       scoreNames: string[];
     });
 
-export declare class Reporter {
+export declare class PageReporter {
   constructor(url: string, config?: Pick<GlobalConfig, keyof GlobalConfig>);
   getReports(): Promise<Report[]>;
 }
+
+export type PageReporterClass = new (
+  url: string,
+  config?: Pick<GlobalConfig, keyof GlobalConfig>,
+) => PageReporter;
+
+export declare class GenericReporter {
+  constructor(config?: Pick<GlobalConfig, keyof GlobalConfig>);
+  getReports(): Promise<Report[]>;
+}
+
+export type GenericReporterClass = new (
+  config?: Pick<GlobalConfig, keyof GlobalConfig>,
+) => GenericReporter;


### PR DESCRIPTION
We now have two types of reports: `PageReporter` for reports on specific pages, and `GenericReporter` for checking the health of our infrastructure.