### PR TITLE
Add AWS Lambda health reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lambda-git": "^0.1.2",
     "lighthouse": "^2.9.1",
     "lodash": "^4.17.5",
+    "moment": "^2.22.0",
     "prettier": "^1.10.2",
     "shelljs": "^0.8.1",
     "tmp": "^0.0.33",

--- a/src/reportPerformance.ts
+++ b/src/reportPerformance.ts
@@ -18,7 +18,8 @@ import { retryCommand } from '@hollowverse/utils/helpers/retryCommand';
 import { SecurityHeadersReporter } from './reporters/SecurityHeadersReporter';
 import { WebPageTestReporter } from './reporters/WebPageTestReporter';
 import { MobileFriendlinessReporter } from './reporters/MobileFriendlinessReporter';
-import { AwsHealthReporter } from './reporters/AwsHealthReporter';
+import { AwsElasticBeanstalkHealthReporter } from './reporters/AwsElasticBeanstalkHealthReporter';
+import { AwsLambdaHealthReporter } from './reporters/AwsLambdaHealthReporter';
 import { GenericReporterClass, PageReporterClass } from './typings/reporter';
 
 // tslint:disable no-console
@@ -37,7 +38,10 @@ export const reportPerformance: Handler = async (_event, _context, done) => {
       WebPageTestReporter,
     ];
 
-    const genericReporters: GenericReporterClass[] = [AwsHealthReporter];
+    const genericReporters: GenericReporterClass[] = [
+      AwsElasticBeanstalkHealthReporter,
+      AwsLambdaHealthReporter,
+    ];
 
     const pageReportsPromise = bluebird.map(urls, async url => ({
       url,

--- a/src/reporters/AwsElasticBeanstalkHealthReporter.ts
+++ b/src/reporters/AwsElasticBeanstalkHealthReporter.ts
@@ -12,7 +12,7 @@ const formatAwsHealth = (color: string) => {
   return awsColorsToFormattedColors[color] || awsColorsToFormattedColors.Grey;
 };
 
-export class AwsHealthReporter implements GenericReporter {
+export class AwsElasticBeanstalkHealthReporter implements GenericReporter {
   private eb: AWS.ElasticBeanstalk;
 
   constructor() {

--- a/src/reporters/AwsLambdaHealthReporter.ts
+++ b/src/reporters/AwsLambdaHealthReporter.ts
@@ -75,7 +75,7 @@ export class AwsLambdaHealthReporter implements GenericReporter {
       {
         name: 'AWS Lambda Health',
         testName: 'Function',
-        scoreNames: ['Number of Invocation Errors'],
+        scoreNames: ['Number of Invocation Errors (for the past 24 hours)'],
         records,
       },
     ];

--- a/src/reporters/AwsLambdaHealthReporter.ts
+++ b/src/reporters/AwsLambdaHealthReporter.ts
@@ -1,0 +1,83 @@
+import { GenericReporter, Report, TestRecord } from '../typings/reporter';
+import awsSdk from 'aws-sdk';
+import moment from 'moment';
+import bluebird from 'bluebird';
+import { defaultFormat } from '../helpers/format';
+import { sum } from 'lodash';
+
+export class AwsLambdaHealthReporter implements GenericReporter {
+  private cloudWatch: AWS.CloudWatch;
+  private lambda: AWS.Lambda;
+
+  constructor() {
+    this.lambda = new awsSdk.Lambda({
+      apiVersion: '2015-03-31',
+    });
+
+    this.cloudWatch = new awsSdk.CloudWatch({
+      apiVersion: '2010-08-01',
+    });
+  }
+
+  async getReports(): Promise<Report[]> {
+    const { Functions } = await this.lambda.listFunctions().promise();
+
+    if (!Functions) {
+      throw new TypeError(
+        'Expected AWS Lambda API call to return a list of functions',
+      );
+    }
+
+    const records = await bluebird.map(
+      Functions,
+      async ({ FunctionName }): Promise<TestRecord> => {
+        if (!FunctionName) {
+          throw new TypeError(
+            'Expected AWS Lambda API call to include function names',
+          );
+        }
+
+        const { Datapoints } = await this.cloudWatch
+          .getMetricStatistics({
+            Namespace: 'AWS/Lambda',
+            Dimensions: [
+              {
+                Name: 'FunctionName',
+                Value: FunctionName,
+              },
+            ],
+            Statistics: ['Sum'],
+            MetricName: 'Errors',
+            Period: 60,
+            StartTime: moment()
+              .subtract(1, 'day')
+              .toDate(),
+            EndTime: new Date(),
+          })
+          .promise();
+
+        if (!Datapoints) {
+          throw new TypeError(
+            'Expected AWS CloudWatch API call to include datapoints',
+          );
+        }
+
+        return {
+          name: FunctionName,
+          scores: [sum(Datapoints.map(({ Sum }) => Sum))],
+          formatScore: defaultFormat,
+        };
+      },
+      { concurrency: 10 },
+    );
+
+    return [
+      {
+        name: 'AWS Lambda Health',
+        testName: 'Function',
+        scoreNames: ['Number of Invocation Errors'],
+        records,
+      },
+    ];
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5641,6 +5641,10 @@ moment@2.x.x, moment@^2.13.0:
   version "2.21.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
 
+moment@^2.22.0:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
One caveat: `assignEnvironment` metrics are not correct. Actually, there are no metrics at all in the Lambda dashboard for this function. All the numbers are zero. I'll look into that later.