### PR TITLE
Add dev.hollowverse.com URLs to report

### DIFF
--- a/src/reportPerformance.ts
+++ b/src/reportPerformance.ts
@@ -23,7 +23,12 @@ import { GenericReporterClass, PageReporterClass } from './typings/reporter';
 
 // tslint:disable no-console max-func-body-length
 export const reportPerformance = async () => {
-  const urls = ['https://hollowverse.com', 'https://hollowverse.com/Tom_Hanks'];
+  const urls = [
+    'https://hollowverse.com',
+    'https://hollowverse.com/Tom_Hanks',
+    'https://dev.hollowverse.com',
+    'https://dev.hollowverse.com/Tom_Hanks',
+  ];
   const dateStr = formatDate(new Date(), 'YYYY-MM-DD');
 
   const pageReporters: PageReporterClass[] = [


### PR DESCRIPTION
I'd like to see some data comparing the new Lambda-based routing solution to what we currently have.